### PR TITLE
Compatibility Python 3

### DIFF
--- a/sentry_mattermost/__init__.py
+++ b/sentry_mattermost/__init__.py
@@ -1,0 +1,5 @@
+try:
+    VERSION = __import__('pkg_resources') \
+        .get_distribution(__name__).version
+except:
+    VERSION = '0.0.1'

--- a/sentry_mattermost/plugin.py
+++ b/sentry_mattermost/plugin.py
@@ -92,6 +92,7 @@ class PayloadFactory:
 
 
 def request(url, payload):
+    # The User-Agent is present to prevent servers from rejecting webhook calls by adding a common user agent
     req = requests.post(url, data=json.dumps(payload), headers={'User-Agent': "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:84.0) Gecko/20100101 Firefox/84.0"})
     return req.status_code
 

--- a/sentry_mattermost/plugin.py
+++ b/sentry_mattermost/plugin.py
@@ -18,8 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import urllib2
 import logging
+import requests
 
 from sentry import tagstore
 from sentry.plugins.bases import notify
@@ -92,12 +92,8 @@ class PayloadFactory:
 
 
 def request(url, payload):
-    data = "payload=" + json.dumps(payload)
-    # Prevent servers from rejecting webhook calls by adding a existing user agent
-    req = urllib2.Request(url, data, headers={
-                          'User-Agent': "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0"})
-    response = urllib2.urlopen(req)
-    return response.read()
+    req = request.post(url, data=json.dumps(payload))
+    return request.status_code
 
 
 class Mattermost(CorePluginMixin, notify.NotificationPlugin):

--- a/sentry_mattermost/plugin.py
+++ b/sentry_mattermost/plugin.py
@@ -92,8 +92,8 @@ class PayloadFactory:
 
 
 def request(url, payload):
-    req = request.post(url, data=json.dumps(payload))
-    return request.status_code
+    req = requests.post(url, data=json.dumps(payload))
+    return req.status_code
 
 
 class Mattermost(CorePluginMixin, notify.NotificationPlugin):

--- a/sentry_mattermost/plugin.py
+++ b/sentry_mattermost/plugin.py
@@ -92,7 +92,7 @@ class PayloadFactory:
 
 
 def request(url, payload):
-    req = requests.post(url, data=json.dumps(payload))
+    req = requests.post(url, data=json.dumps(payload), headers={'User-Agent': "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:84.0) Gecko/20100101 Firefox/84.0"})
     return req.status_code
 
 


### PR DESCRIPTION
Latest version of Sentry/OnPremise Docker containers are running Python 3, no Python 2 installed.

This PR removes the use of "urllib2" that a Python 2 library and replace it by "requests".