### PR TITLE
Feature: Make Channel url configurable

### DIFF
--- a/sentry_mattermost/plugin.py
+++ b/sentry_mattermost/plugin.py
@@ -87,6 +87,8 @@ class PayloadFactory:
             "icon_url": "https://myovchev.github.io/sentry-slack/images/logo32.png",  # noqa
             "text": text
         }
+        if plugin.get_option('channel', project):
+            payload["channel"] = plugin.get_option('channel', project)
         return payload
 
 
@@ -146,6 +148,13 @@ class Mattermost(CorePluginMixin, notify.NotificationPlugin):
                 "type": "bool",
                 "required": False,
                 "help": "Include tags with notifications."
+            },
+            {
+                "name": "channel",
+                "label": "Channel Name",
+                "type": "string",
+                "required": False,
+                "help": "Mattermost channel name, leave empty for default channel defined by webhook",
             },
             {
                 "name": "debug",


### PR DESCRIPTION
We recently upgraded our Sentry instance and found your fork that made the plugin compatible again, thanks for that!

I cherry-picked my original [PR for NDrive's repo](https://github.com/NDrive/sentry-mattermost/pull/12) with this repo.

I makes the channel name configurable, so it is very convenient to configure one Mattermost webhook for a variety of Mattermost channel/repo configurations.

![Bildschirmfoto 2022-10-25 um 15 16 00](https://user-images.githubusercontent.com/147175/197783171-36c5e995-076f-4905-b745-881cb3dadca8.png)

